### PR TITLE
add getNode method to get animated component node directly

### DIFF
--- a/src/with-collapsible-header.tsx
+++ b/src/with-collapsible-header.tsx
@@ -239,6 +239,10 @@ export const withCollapsibleHeader = <T extends ScrollViewProps>(
       return this.wrappedComponent.current
     }
 
+    public getNode = () => {
+      return this.wrappedComponent.current.getNode()
+    }
+
     public showHeader = (options: AnimationConfig | unknown) => {
       this.moveHeader(
         this.offsetValue - this.props.headerHeight,


### PR DESCRIPTION
I add getNode() method to get animated component node directly, so you don't need to type like this:
`this.ref.scrollview.animatedComponent().getNode().scrollToEnd()`
Just type like this:
`this.ref.scrollview.getNode().scrollToEnd()`

referenced issue: #6 